### PR TITLE
:wrench: Set docs base url

### DIFF
--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -3,6 +3,7 @@ import { withMermaid } from "vitepress-plugin-mermaid";
 
 // https://vitepress.dev/reference/site-config
 const vitepressConfig = defineConfig({
+  base: "/stadtbezirksbudget/",
   title: "RefArch Docs Template",
   description: "Documentation template from the RefArch Templates",
   head: [


### PR DESCRIPTION
- Set docs base url to `/stadtbezirksbudget/`
- Necessary because the github pages url is [it-at-m.github.io/stadtbezirksbudget/](https://it-at-m.github.io/stadtbezirksbudget/)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* Documentation
  * Updated the documentation site’s base path to “/stadtbezirksbudget/”. URLs, navigation, and assets now load correctly when the site is hosted under this subpath.
  * Reduces broken links and 404s on deployed environments by aligning all internal links with the new base path.
  * Users accessing the docs from the root path may need to update bookmarks to the new location.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->