### PR TITLE
🔧 Update renovate config to use gitmoji

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -8,7 +8,7 @@
   "commitMessageAction": "Upgrade",
   "packageRules": [
     {
-      "matchUpdateTypes": ["pin"],
+      "matchUpdateTypes": ["pin", "pinDigest", "digest"],
       "commitMessagePrefix": "📌",
       "commitMessageAction": "Pin"
     },

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -1,0 +1,23 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": [
+    "github>it-at-m/refarch//refarch-tools/refarch-renovate/refarch-renovate-config.json5",
+  ],
+  "labels": ["📌 Dependencies"],
+  "commitMessagePrefix": "⬆️",
+  "commitMessageAction": "Upgrade",
+  "packageRules": [
+    {
+      "matchUpdateTypes": ["pin"],
+      "commitMessagePrefix": "📌",
+      "commitMessageAction": "Pin"
+    },
+    {
+      "matchUpdateTypes": ["rollback"],
+      "commitMessagePrefix": "⬇️",
+      "commitMessageAction": "Downgrade"
+    }
+  ],
+  "dependencyDashboardTitle": "📌 Dependency Dashboard",
+  "dependencyDashboardLabels": ["📌 Dependencies"]
+}

--- a/renovate.json5
+++ b/renovate.json5
@@ -1,6 +1,0 @@
-{
-  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": [
-    "github>it-at-m/refarch//refarch-tools/refarch-renovate/refarch-renovate-config.json5",
-  ]
-}


### PR DESCRIPTION
# Pull Request

<!-- Links -->
[code-quality-link]: https://refarch.oss.muenchen.de/templates/develop#code-quality
[refarch-create-issue-link]: https://github.com/it-at-m/refarch/issues/new/choose
[refarch-create-documentation-issue-link]: https://github.com/it-at-m/refarch/issues/new?template=4-documentation-change.yml

## Changes

- Update renovate config to use gitmoji

## Reference

Issue: #62 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Chores
  - Added a new dependency automation configuration to standardize upgrade, pin, and rollback workflows.
  - Applied consistent commit prefixes, actions, and labels for dependency changes.
  - Introduced a dedicated "Dependency Dashboard" with standardized labeling.
  - Removed a legacy configuration to avoid duplication.
  - No user-facing changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->