### PR TITLE
:wrench: Update renovate schedule to weekends

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -4,6 +4,7 @@
     "github>it-at-m/refarch//refarch-tools/refarch-renovate/refarch-renovate-config.json5",
     "schedule:weekends",
   ],
+  "timezone": "Europe/Berlin",
   "labels": ["📌 Dependencies"],
   "commitMessagePrefix": "⬆️",
   "commitMessageAction": "Upgrade",


### PR DESCRIPTION
# Pull Request

<!-- Links -->
[code-quality-link]: https://refarch.oss.muenchen.de/templates/develop#code-quality
[refarch-create-issue-link]: https://github.com/it-at-m/refarch/issues/new/choose
[refarch-create-documentation-issue-link]: https://github.com/it-at-m/refarch/issues/new?template=4-documentation-change.yml

## Changes

- Update renovate schedule to weekends

## Reference

Issue: #91 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Automated dependency updates are now scheduled to run on weekends (Europe/Berlin timezone).
  * Existing labeling, commit message conventions, and dependency dashboard settings remain unchanged.
  * Maintenance-only configuration update; no impact to features, UI, performance, or data.
  * Transparent rollout across environments; no user action required.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->