### PR TITLE
🔧 Use quay.io registry for keycloak image

### DIFF
--- a/stack/docker-compose.yml
+++ b/stack/docker-compose.yml
@@ -42,7 +42,7 @@ services:
     entrypoint: /bin/sh -c "chmod 600 /pgadmin4/pgpass; /entrypoint.sh;" # see https://www.postgresql.org/docs/current/libpq-pgpass.html#LIBPQ-PGPASS (last paragraph)
 
   keycloak:
-    image: keycloak/keycloak:26.4.1@sha256:bbb299c7e58a2c61c683dc3439da3e2698e005ca88ba6fd249629311d70250ab
+    image: quay.io/keycloak/keycloak:26.4.1@sha256:bbb299c7e58a2c61c683dc3439da3e2698e005ca88ba6fd249629311d70250ab
     command:
       - start-dev
     environment:


### PR DESCRIPTION
# Pull Request

## Changes

- Use quay.io for keycloak image instead of default registry 

## Reference

https://github.com/it-at-m/refarch-templates/pull/1270

## Checklist

- [x] ~Updated documentation~
- [x] ~Added automated tests (unit/integration/component)~
- [x] ~Complied with UI/UX design (if UI change was made)~
- [x] ~Met all acceptance criteria of the issue~
