### PR TITLE
⬇️ Downgrade to hibernate-jpamodelgen with auto version

### DIFF
--- a/stadtbezirksbudget-backend/pom.xml
+++ b/stadtbezirksbudget-backend/pom.xml
@@ -69,7 +69,6 @@
         <commons-text.version>1.14.0</commons-text.version>
         <mapstruct.version>1.6.3</mapstruct.version>
         <refarch-tools.version>1.2.0</refarch-tools.version>
-        <hibernate-processor.version>7.1.10.Final</hibernate-processor.version>
 
         <!-- Additional required dependencies -->
         <lombok-mapstruct-binding.version>0.2.0</lombok-mapstruct-binding.version> <!-- Needed to make MapStruct and Lombok work together -->
@@ -167,12 +166,6 @@
         <dependency>
             <groupId>org.flywaydb</groupId>
             <artifactId>flyway-database-postgresql</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.hibernate.orm</groupId>
-            <artifactId>hibernate-processor</artifactId>
-            <version>${hibernate-processor.version}</version>
-            <scope>provided</scope>
         </dependency>
 
         <!-- Other -->
@@ -317,8 +310,7 @@
                         </path>
                         <path>
                             <groupId>org.hibernate.orm</groupId>
-                            <artifactId>hibernate-processor</artifactId>
-                            <version>${hibernate-processor.version}</version>
+                            <artifactId>hibernate-jpamodelgen</artifactId> <!-- Needs to be changed to hibernate-processor on hibernate v7 upgrade -->
                         </path>
                     </annotationProcessorPaths>
                     <showDeprecation>true</showDeprecation>


### PR DESCRIPTION
# Pull Request

## Changes

- Downgrade to hibernate-jpamodelgen with auto version

### Context

Using `hibernate-processor` only makes sense with Hibernate ORM 7.x, because the Metamodel processor was renamed starting with the 7.x line. However, Spring Boot 3.5.8 manages Hibernate ORM 6.x, which still uses the old `hibernate-jpamodelgen` processor. Mixing Hibernate 6.x at runtime with the 7.x annotation processor can lead to incompatible or incorrect metamodel classes. Therefore, when using Spring Boot 3.5.8, the correct choice is to use `hibernate-jpamodelgen` with the matching 6.x version. When upgrading to Spring Boot 4, which will use Hibernate ORM 7.x, the dependency must be switched from `hibernate-jpamodelgen` to `hibernate-processor`.

## Reference

https://github.com/it-at-m/stadtbezirksbudget/pull/377#discussion_r2576139099

## Checklist

- [x] ~Updated documentation~
- [x] ~Added automated tests (unit/integration/component)~
- [x] ~Complied with UI/UX design (if UI change was made)~
- [x] ~Met all acceptance criteria of the issue~
