### PR TITLE
✅ Decouple list api test from filters object

### DIFF
--- a/stadtbezirksbudget-frontend/tests/api/fetch-antragSummary-list.test.ts
+++ b/stadtbezirksbudget-frontend/tests/api/fetch-antragSummary-list.test.ts
@@ -1,34 +1,10 @@
-import type { AntragListFilter } from "@/types/AntragListFilter";
-
 import { afterEach, describe, expect, test, vi } from "vitest";
 
 import { getAntragsSummaryList } from "@/api/fetch-antragSummary-list.ts";
 import { BACKEND } from "@/constants.ts";
 import { defaultAntragListFilter } from "@/types/AntragListFilter";
-import { antragListFilterToDTO } from "@/types/AntragListFilterDTO.ts";
-import { objectToSearchParams } from "@/util/converter";
 
 global.fetch = vi.fn();
-
-const testFilters: AntragListFilter = {
-  status: ["EINGEGANGEN", "ABGESCHLOSSEN"],
-  bezirksausschussNr: [1, 5],
-  eingangDatum: [
-    new Date("2025-11-26T00:00:00Z"),
-    new Date("2025-11-27T00:00:00Z"),
-    new Date("2025-11-28T00:00:00Z"),
-  ],
-  antragstellerName: "TEST_NAME",
-  projektTitel: "TEST_TITEL",
-  beantragtesBudgetVon: 537.25,
-  beantragtesBudgetBis: 1098.98,
-  art: "Fest",
-  aktualisierungArt: ["E_AKTE"],
-  aktualisierungDatum: [new Date("2025-11-25T00:00:00Z")],
-};
-const testFiltersString = objectToSearchParams(
-  antragListFilterToDTO(testFilters)
-).toString();
 
 const mockResponse = {
   content: [],
@@ -61,10 +37,10 @@ describe("fetch-antragSummary-list", () => {
       json: async () => mockResponse,
     });
 
-    await getAntragsSummaryList(1, 5, testFilters);
+    await getAntragsSummaryList(1, 5, { filter: "value" });
 
     expect(fetch).toHaveBeenCalledWith(
-      `${BACKEND}/antrag?page=1&size=5&${testFiltersString}`,
+      `${BACKEND}/antrag?page=1&size=5&filter=value`,
       expect.any(Object)
     );
   });


### PR DESCRIPTION
# Pull Request

## Changes

- `fetch-antragSummary-list.test.ts` doesn't use `AntragListFilter` anymore
- Therefore decoupled and not dependent on `AntragListFilter`

## Reference

Issue: - (Kleinständerung)

## Checklist

- [x] ~Updated documentation~
- [x] Added automated tests (unit/integration/component)
- [x] ~Complied with UI/UX design (if UI change was made)~
- [x] ~Met all acceptance criteria of the issue~


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Simplified test setup for API filtering functionality to reduce dependencies and improve test maintainability.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->