### PR TITLE
:recycle: Remove duplicate error message definitions in api functions

### DIFF
--- a/stadtbezirksbudget-frontend/src/api/fetch-antragListFilterOptions.ts
+++ b/stadtbezirksbudget-frontend/src/api/fetch-antragListFilterOptions.ts
@@ -18,6 +18,6 @@ export function getAntragListFilterOptions(): Promise<AntragListFilterOptions> {
       return response.json();
     })
     .catch((err) => {
-      return defaultCatchHandler(err, "Fehler beim Laden der Filteroptionen.");
+      return defaultCatchHandler(err);
     });
 }

--- a/stadtbezirksbudget-frontend/src/api/fetch-antragSummary-list.ts
+++ b/stadtbezirksbudget-frontend/src/api/fetch-antragSummary-list.ts
@@ -42,6 +42,6 @@ export function getAntragsSummaryList(
       return response.json();
     })
     .catch((err) => {
-      return defaultCatchHandler(err, "Fehler beim Laden der Antragsliste.");
+      return defaultCatchHandler(err);
     });
 }

--- a/stadtbezirksbudget-frontend/src/api/update-antragStatus.ts
+++ b/stadtbezirksbudget-frontend/src/api/update-antragStatus.ts
@@ -25,9 +25,6 @@ export function updateAntragStatus(
   )
     .then(defaultResponseHandler)
     .catch((err) => {
-      return defaultCatchHandler(
-        err,
-        "Fehler beim Aktualisieren des Antragsstatus"
-      );
+      return defaultCatchHandler(err);
     });
 }

--- a/stadtbezirksbudget-frontend/src/composables/useAntragStatusUpdate.ts
+++ b/stadtbezirksbudget-frontend/src/composables/useAntragStatusUpdate.ts
@@ -39,15 +39,14 @@ export function useAntragStatusUpdate(
         status.value = newStatus;
         oldStatus.value = newStatus;
         snackbarStore.showMessage({
-          message: `Antragsstatus aktualisiert`,
+          message: "Antragsstatus aktualisiert",
           level: STATUS_INDICATORS.SUCCESS,
         });
       })
-      .catch((error) => {
+      .catch(() => {
         status.value = oldStatus.value;
         snackbarStore.showMessage({
-          message:
-            error?.message || "Fehler beim Aktualisieren des Antragsstatus",
+          message: "Fehler beim Aktualisieren des Antragsstatus",
           level: STATUS_INDICATORS.WARNING,
         });
       })

--- a/stadtbezirksbudget-frontend/src/composables/useAntragSummaryList.ts
+++ b/stadtbezirksbudget-frontend/src/composables/useAntragSummaryList.ts
@@ -55,9 +55,9 @@ export function useAntragSummaryList() {
         items.value = content.content;
         totalItems.value = content.page.totalElements;
       })
-      .catch((error) => {
+      .catch(() => {
         snackbarStore.showMessage({
-          message: error?.message || "Fehler beim Laden der Anträge",
+          message: "Fehler beim Laden der Anträge",
           level: STATUS_INDICATORS.WARNING,
         });
       })

--- a/stadtbezirksbudget-frontend/src/composables/useInitializeStores.ts
+++ b/stadtbezirksbudget-frontend/src/composables/useInitializeStores.ts
@@ -19,9 +19,9 @@ export function useInitializeStores() {
       .then((options: AntragListFilterOptions) => {
         antragListFilterOptionsStore.setFilterOptions(options);
       })
-      .catch((error) => {
+      .catch(() => {
         snackbarStore.showMessage({
-          message: error?.message || "Fehler beim Laden der Filteroptionen",
+          message: "Fehler beim Laden der Filteroptionen",
           level: STATUS_INDICATORS.WARNING,
         });
       });

--- a/stadtbezirksbudget-frontend/tests/api/fetch-antragListFilterOptions.test.ts
+++ b/stadtbezirksbudget-frontend/tests/api/fetch-antragListFilterOptions.test.ts
@@ -39,7 +39,7 @@ describe("fetch-antragListFilterOptions", () => {
     );
 
     await expect(getAntragListFilterOptions()).rejects.toThrow(
-      "Fehler beim Laden der Filteroptionen."
+      "Es ist ein unbekannter Fehler aufgetreten."
     );
   });
 

--- a/stadtbezirksbudget-frontend/tests/api/fetch-antragSummary-list.test.ts
+++ b/stadtbezirksbudget-frontend/tests/api/fetch-antragSummary-list.test.ts
@@ -99,7 +99,7 @@ describe("fetch-antragSummary-list", () => {
         defaultAntragListFilter(),
         createEmptyListSort()
       )
-    ).rejects.toThrow("Fehler beim Laden der Antragsliste.");
+    ).rejects.toThrow("Es ist ein unbekannter Fehler aufgetreten.");
   });
 
   test("handles http errors", async () => {

--- a/stadtbezirksbudget-frontend/tests/api/update-antragStatus.test.ts
+++ b/stadtbezirksbudget-frontend/tests/api/update-antragStatus.test.ts
@@ -36,7 +36,7 @@ describe("update-antragStatus", () => {
     );
 
     await expect(updateAntragStatus("456", "ABGELEHNT")).rejects.toThrow(
-      "Fehler beim Aktualisieren des Antragsstatus"
+      "Es ist ein unbekannter Fehler aufgetreten."
     );
   });
 
@@ -48,7 +48,7 @@ describe("update-antragStatus", () => {
     });
 
     await expect(updateAntragStatus("789", "ABGELEHNT")).rejects.toThrow(
-      "Fehler beim Aktualisieren des Antragsstatus"
+      "Es ist ein unbekannter Fehler aufgetreten."
     );
   });
 });

--- a/stadtbezirksbudget-frontend/tests/composables/useAntragStatusUpdate.test.ts
+++ b/stadtbezirksbudget-frontend/tests/composables/useAntragStatusUpdate.test.ts
@@ -63,7 +63,7 @@ describe("useAntragStatusUpdate", () => {
       await vi.waitFor(() => {
         expect(status.value).toBe("EINGEGANGEN");
         expect(snackbarStoreMock.showMessage).toHaveBeenCalledWith({
-          message: "API Error",
+          message: "Fehler beim Aktualisieren des Antragsstatus",
           level: STATUS_INDICATORS.WARNING,
         });
       });

--- a/stadtbezirksbudget-frontend/tests/composables/useAntragSummaryList.test.ts
+++ b/stadtbezirksbudget-frontend/tests/composables/useAntragSummaryList.test.ts
@@ -96,9 +96,8 @@ describe("useAntragSummaryList", () => {
     });
 
     test("handles api errors when fetching items", async () => {
-      const errorMessage = "API Error";
       (getAntragsSummaryList as vi.Mock).mockRejectedValue(
-        new Error(errorMessage)
+        new Error("API Error")
       );
 
       const { fetchItems, loading } = useAntragSummaryList();
@@ -106,7 +105,7 @@ describe("useAntragSummaryList", () => {
 
       await vi.waitFor(() => {
         expect(snackbarStoreMock.showMessage).toHaveBeenCalledWith({
-          message: errorMessage,
+          message: "Fehler beim Laden der Anträge",
           level: STATUS_INDICATORS.WARNING,
         });
         expect(loading.value).toBe(false);

--- a/stadtbezirksbudget-frontend/tests/composables/useInitializeStores.test.ts
+++ b/stadtbezirksbudget-frontend/tests/composables/useInitializeStores.test.ts
@@ -52,27 +52,11 @@ describe("useInitializeStores", () => {
       expect(setFilterOptions).toHaveBeenCalledWith(apiResult);
     });
 
-    test("shows snackbar with error.message if API throws error with message", async () => {
+    test("shows snackbar with error message if API throws error ", async () => {
       const apiMock = getAntragListFilterOptions as unknown as vi.Mock;
       const showMessage = useSnackbarStore().showMessage as vi.Mock;
       const error = new Error("network error");
       apiMock.mockRejectedValue(error);
-
-      mount(Comp);
-
-      await Promise.resolve();
-      await nextTick();
-
-      expect(showMessage).toHaveBeenCalledWith({
-        message: error.message,
-        level: STATUS_INDICATORS.WARNING,
-      });
-    });
-
-    test("shows snackbar with fallback message if error has no message", async () => {
-      const apiMock = getAntragListFilterOptions as unknown as vi.Mock;
-      const showMessage = useSnackbarStore().showMessage as vi.Mock;
-      apiMock.mockRejectedValue({});
 
       mount(Comp);
 


### PR DESCRIPTION
# Pull Request

## Changes

- Remove duplicate error message definitions in api functions

### Context

Before we defined error messages twice, in the api function and in the composable calling this api function. This was unnecessary. Therefore, in the team, we decided to remove the error message in the api function and only define the messages in the composables. With this setup, all messages (error and success) are defined in the composable and not mixed up in the codebase.

## Reference

Issue: - (micro change)

## Checklist

- [x] ~Updated documentation~
- [x] Added automated tests (unit/integration/component)
- [x] ~Complied with UI/UX design (if UI change was made)~
- [x] ~Met all acceptance criteria of the issue~


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Standardized error handling and messaging across API calls and composables for consistency.
  * Replaced custom error messages with unified generic error handling.
  * Simplified error handling logic by removing unused error object parameters.
  * Updated tests to reflect standardized error messages.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->