### PR TITLE
:wrench: Add v-Prefix in kafka-ui tag to fix renovate warning

### DIFF
--- a/stack/docker-compose.yml
+++ b/stack/docker-compose.yml
@@ -167,7 +167,7 @@ services:
       - kafka
 
   kafka-ui:
-    image: ghcr.io/kafbat/kafka-ui:1.4.2@sha256:8dd62c9b18a01b732824cae91c6fe5203fac8e931448a2a639bd20270b8fed2b
+    image: ghcr.io/kafbat/kafka-ui:v1.4.2@sha256:8dd62c9b18a01b732824cae91c6fe5203fac8e931448a2a639bd20270b8fed2b
     ports:
       - "8089:8080"
     depends_on:


### PR DESCRIPTION
# Pull Request

## Changes

- Add v-Prefix in kafka-ui tag to fix renovate warning

### Context

Renovate was unable to determine a new digest for the `kafka-ui`, resulting in the following error:

```
Renovate failed to look up the following dependencies:
Could not determine new digest for update (docker package ghcr.io/kafbat/kafka-ui)
```

To resolve this issue, the `stack/docker-compose.yml` file has been updated to include the correct tag format. The actual tag for the Kafka UI image is `v1.4.2`, as indicated in the [GitHub Packages](https://github.com/kafbat/kafka-ui/pkgs/container/kafka-ui/574185821?tag=v1.4.2). The `v`-prefix has been added to align with the correct tagging convention.

This change aims to eliminate the Renovate warning and ensure proper dependency management.

## Reference

Issue: - (micro-change)

## Checklist

- [x] ~Updated documentation~
- [x] ~Added automated tests (unit/integration/component)~
- [x] ~Complied with UI/UX design (if UI change was made)~
- [x] ~Met all acceptance criteria of the issue~


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Kafka UI service image reference tag format for consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->